### PR TITLE
User text/plain content type for error responses

### DIFF
--- a/lambda/lambda.js
+++ b/lambda/lambda.js
@@ -75,7 +75,7 @@ function notAuthorized() {
             }],
             'content-type': [{
                 key: 'Content-Type',
-                value: 'text/html'
+                value: 'text/plain; charset=UTF-8'
             }],
             'x-content-type-options': [{
                 key: 'X-Content-Type-Options',


### PR DESCRIPTION
This way if the message is changed in the future, there will be no need to escape it.