### PR TITLE
Token type matching should be case-insensitive

### DIFF
--- a/lambda/lambda.js
+++ b/lambda/lambda.js
@@ -52,8 +52,8 @@ function parseToken(headers) {
     if (authorization.length > 0) {
         for (let i = 0; i < authorization.length; i++) {
             const token = authorization[i].value || ''
-            const prefix = 'Bearer ';
-            if (token.startsWith(prefix)) {
+            const prefix = 'bearer ';
+            if (token.toLowerCase().startsWith(prefix)) {
                 return token.substring(prefix.length)
             }
         }


### PR DESCRIPTION
See https://datatracker.ietf.org/doc/html/rfc2617#section-1.2